### PR TITLE
Mainly WiredModem/Cable fixes

### DIFF
--- a/src/main/java/dan200/computercraft/ComputerCraft.java
+++ b/src/main/java/dan200/computercraft/ComputerCraft.java
@@ -44,7 +44,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static dan200.computercraft.shared.ComputerCraftRegistry.ModBlocks;
 import static dan200.computercraft.shared.ComputerCraftRegistry.init;
 
 public final class ComputerCraft implements ModInitializer

--- a/src/main/java/dan200/computercraft/client/render/CableHighlightRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/CableHighlightRenderer.java
@@ -18,6 +18,7 @@ import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.Entity;
+import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.*;
 import net.minecraft.util.shape.VoxelShape;
 
@@ -40,8 +41,12 @@ public final class CableHighlightRenderer
             return false;
         }
 
+        HitResult hitResult = MinecraftClient.getInstance().crosshairTarget;
+
+        Vec3d hitPos = hitResult != null ? hitResult.getPos() : new Vec3d( d, e, f );
+
         VoxelShape shape = WorldUtil.isVecInside( CableShapes.getModemShape( state ),
-            new Vec3d( d, e, f ).subtract( pos.getX(),
+            hitPos.subtract( pos.getX(),
                 pos.getY(),
                 pos.getZ() ) ) ? CableShapes.getModemShape( state ) : CableShapes.getCableShape(
             state );

--- a/src/main/java/dan200/computercraft/fabric/mixin/MixinWorld.java
+++ b/src/main/java/dan200/computercraft/fabric/mixin/MixinWorld.java
@@ -7,6 +7,7 @@ package dan200.computercraft.fabric.mixin;
 
 import dan200.computercraft.shared.common.TileGeneric;
 import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -26,12 +27,18 @@ import java.util.Collection;
 public class MixinWorld
 {
     @Shadow
-    protected boolean iteratingTickingBlockEntities;
+    private boolean iteratingTickingBlockEntities;
+
+    @Shadow
+    public boolean isInBuildLimit( BlockPos pos )
+    {
+        return false;
+    }
 
     @Inject( method = "addBlockEntity", at = @At( "HEAD" ) )
     public void addBlockEntity( @Nullable BlockEntity entity, CallbackInfo info )
     {
-        if( entity != null && !entity.isRemoved() && entity.getWorld() != null && entity.getWorld().isInBuildLimit( entity.getPos() ) && iteratingTickingBlockEntities )
+        if( entity != null && !entity.isRemoved() && this.isInBuildLimit( entity.getPos() ) && iteratingTickingBlockEntities )
         {
             setWorld( entity, this );
         }
@@ -41,7 +48,7 @@ public class MixinWorld
     {
         if( entity.getWorld() != world && entity instanceof TileGeneric )
         {
-            entity.setWorld( (World) world ); //TODO why?
+            entity.setWorld( (World) world );
         }
     }
 

--- a/src/main/java/dan200/computercraft/shared/peripheral/modem/wired/BlockCable.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/modem/wired/BlockCable.java
@@ -232,9 +232,8 @@ public class BlockCable extends BlockGeneric implements Waterloggable
     public void onPlaced( World world, @Nonnull BlockPos pos, @Nonnull BlockState state, LivingEntity placer, @Nonnull ItemStack stack )
     {
         BlockEntity tile = world.getBlockEntity( pos );
-        if( tile instanceof TileCable )
+        if( tile instanceof TileCable cable )
         {
-            TileCable cable = (TileCable) tile;
             if( cable.hasCable() )
             {
                 cable.connectionsChanged();

--- a/src/main/java/dan200/computercraft/shared/peripheral/modem/wired/ItemBlockCable.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/modem/wired/ItemBlockCable.java
@@ -56,9 +56,8 @@ public abstract class ItemBlockCable extends BlockItem
         world.playSound( null, pos, soundType.getPlaceSound(), SoundCategory.BLOCKS, (soundType.getVolume() + 1.0F) / 2.0F, soundType.getPitch() * 0.8F );
 
         BlockEntity tile = world.getBlockEntity( pos );
-        if( tile instanceof TileCable )
+        if( tile instanceof TileCable cable )
         {
-            TileCable cable = (TileCable) tile;
             cable.modemChanged();
             cable.connectionsChanged();
         }

--- a/src/main/java/dan200/computercraft/shared/proxy/ComputerCraftProxyCommon.java
+++ b/src/main/java/dan200/computercraft/shared/proxy/ComputerCraftProxyCommon.java
@@ -25,6 +25,7 @@ import dan200.computercraft.shared.media.items.RecordMedia;
 import dan200.computercraft.shared.network.NetworkHandler;
 import dan200.computercraft.shared.peripheral.commandblock.CommandBlockPeripheral;
 import dan200.computercraft.shared.peripheral.generic.methods.InventoryMethods;
+import dan200.computercraft.shared.peripheral.modem.wired.BlockCable;
 import dan200.computercraft.shared.peripheral.modem.wireless.WirelessNetwork;
 import dan200.computercraft.shared.turtle.FurnaceRefuelHandler;
 import dan200.computercraft.shared.turtle.SignInspectHandler;
@@ -34,6 +35,7 @@ import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerBlockEntityEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.CommandBlockBlockEntity;
 import net.minecraft.item.Item;
@@ -121,6 +123,11 @@ public final class ComputerCraftProxyCommon
             {
                 ((TileGeneric) blockEntity).onChunkUnloaded();
             }
+        } );
+
+        PlayerBlockBreakEvents.BEFORE.register( ( world, player, pos, state, blockEntity ) -> {
+            if ( state.getBlock() instanceof BlockCable blockCable ) return blockCable.removedByPlayer( state, world, pos, player, false, null );
+            return true;
         } );
 
         // Config


### PR DESCRIPTION
* More correct isInBuildLimit check in MixinWorld (world of entity can be null), but I think this mixin need to be revisiting
* Fixed bug with wired modem connection to cable (if wired modem connected to cable, then modem has wrong direction)
* Correct highlighting of cable with wired modem (cable has own highlight, modem own, like in CC:T)
* BlockCable removedByPlayer implementation, so wired modem can be removed from cable and vice versa