### PR TITLE
Force Jitpack to actually use Java 16 instead of Java 8

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,5 @@
+before_install:
+  - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
+  - source ./install-jdk.sh --feature 16 --license GPL
 jdk:
   - openjdk16

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk16


### PR DESCRIPTION
This workaround with `install-jdk.sh` seems to be what everyone else is using too. (https://github.com/jitpack/jitpack.io/issues/4355)
