### PR TITLE
fix MixinLevel cause game crash because it uses the incorect Level

### DIFF
--- a/src/main/java/dan200/computercraft/fabric/mixin/MixinLevel.java
+++ b/src/main/java/dan200/computercraft/fabric/mixin/MixinLevel.java
@@ -31,7 +31,7 @@ public class MixinLevel
     @Inject( method = "setBlockEntity", at = @At( "HEAD" ) )
     public void setBlockEntity( @Nullable BlockEntity entity, CallbackInfo info )
     {
-        if( entity != null && !entity.isRemoved() && ( (Level) (Object) this ).isInWorldBounds( entity.getBlockPos() ) && tickingBlockEntities )
+        if( entity != null && !entity.isRemoved() && ((Level) (Object) this).isInWorldBounds( entity.getBlockPos() ) && tickingBlockEntities )
         {
             setWorld( entity, this );
         }

--- a/src/main/java/dan200/computercraft/fabric/mixin/MixinLevel.java
+++ b/src/main/java/dan200/computercraft/fabric/mixin/MixinLevel.java
@@ -31,7 +31,7 @@ public class MixinLevel
     @Inject( method = "setBlockEntity", at = @At( "HEAD" ) )
     public void setBlockEntity( @Nullable BlockEntity entity, CallbackInfo info )
     {
-        if( entity != null && !entity.isRemoved() && entity.getLevel().isInWorldBounds( entity.getBlockPos() ) && tickingBlockEntities )
+        if( entity != null && !entity.isRemoved() && ( (Level) (Object) this ).isInWorldBounds( entity.getBlockPos() ) && tickingBlockEntities )
         {
             setWorld( entity, this );
         }


### PR DESCRIPTION
Fix game crash on extending a Minecraft Piston.
The Mixin checks if the new BlockEntity in in WorldBounds for the new BlockEntitys Level, but the BlockEntity does not have a Level at this time.