### PR TITLE
Require Fabric 0.39.0 due to BlockEntityRendererRegistry

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,7 +21,7 @@
     ],
     "depends": {
         "fabricloader": ">=0.11.3",
-        "fabric": "*",
+        "fabric": ">=0.39.0",
         "minecraft": "1.17.x",
         "java": ">=16"
     },


### PR DESCRIPTION
`dan200.computercraft.client.proxy.ComputerCraftProxyClient.onInitializeClient` attempts to load `net.fabricmc.fabric.api.client.rendering.v1.BlockEntityRendererRegistry`, which is only present on Fabric API 0.39.0 or later, so if a user is on an earlier Fabric version they'll end up with a crash. This PR adds a hard dependency on 0.39.0 or later.