### PR TITLE
Update gitpod dockerfile with java 17 default

### DIFF
--- a/config/gitpod/Dockerfile
+++ b/config/gitpod/Dockerfile
@@ -13,7 +13,7 @@ USER gitpod
 
 # Install Java 8 and 16
 RUN sudo apt-get -q update && \
-    sudo apt install -yq openjdk-8-jdk openjdk-16-jdk
+    sudo apt install -yq openjdk-8-jdk openjdk-16-jdk openjdk-17-jdk
 
 # This is so that you can use java 8 until such a time as you switch to java 16
-RUN sudo update-java-alternatives --set java-1.16.0-openjdk-amd64
+RUN sudo update-java-alternatives --set java-1.17.0-openjdk-amd64


### PR DESCRIPTION
mc 1.18 requires java 17, as does fabric api, best make sure the remote dev env can do its duty

## A quick checklist
 - If there's a existing issue, please link to it. If not, provide fill out the same information you would in a normal issue - reproduction steps for bugs, rationale for use-case.
 - If you're working on CraftOS, try to write a few test cases so we can ensure everything continues to work in the future. Tests live in `src/test/resources/test-rom/spec` and can be run with `./gradlew check`.
