### PR TITLE
Resolve issue #16 for cc-restitched, center printout in item frame, and fix page flipping for prints.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ mod_version=1.100.0
 # Minecraft properties
 mc_version=1.18.1
 fabric_api_version=0.44.0+1.18
-fabric_loader_version=0.12.11
+fabric_loader_version=0.12.12
 
 cloth_api_version=2.0.54
 cloth_config_version=6.0.42

--- a/src/main/java/dan200/computercraft/client/gui/GuiPrintout.java
+++ b/src/main/java/dan200/computercraft/client/gui/GuiPrintout.java
@@ -53,8 +53,7 @@ public class GuiPrintout extends AbstractContainerScreen<ContainerHeldItem>
     @Override
     public boolean keyPressed( int key, int scancode, int modifiers )
     {
-        if( super.keyPressed( key, scancode, modifiers ) ) return true;
-
+        // Check for key presses.
         if( key == GLFW.GLFW_KEY_RIGHT )
         {
             if( page < pages - 1 ) page++;
@@ -67,13 +66,16 @@ public class GuiPrintout extends AbstractContainerScreen<ContainerHeldItem>
             return true;
         }
 
+        // Otherwise, default to parent function
+        if( super.keyPressed( key, scancode, modifiers ) ) return true;
+
         return false;
     }
 
     @Override
     public boolean mouseScrolled( double x, double y, double delta )
     {
-        if( super.mouseScrolled( x, y, delta ) ) return true;
+        // Check for key presses.
         if( delta < 0 )
         {
             // Scroll up goes to the next page
@@ -87,6 +89,9 @@ public class GuiPrintout extends AbstractContainerScreen<ContainerHeldItem>
             if( page > 0 ) page--;
             return true;
         }
+
+        // Otherwise, default to parent function
+        if( super.mouseScrolled( x, y, delta ) ) return true;
 
         return false;
     }

--- a/src/main/java/dan200/computercraft/client/render/ItemPrintoutRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/ItemPrintoutRenderer.java
@@ -63,7 +63,7 @@ public final class ItemPrintoutRenderer extends ItemMapLikeRenderer
         double height = LINES_PER_PAGE * FONT_HEIGHT + Y_TEXT_MARGIN * 2;
 
         // Non-books will be left aligned
-        if( !book ) width += offsetAt( pages );
+        if( !book ) width += offsetAt( pages - 1 );
 
         double visualWidth = width, visualHeight = height;
 

--- a/src/main/java/dan200/computercraft/client/render/PrintoutRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/PrintoutRenderer.java
@@ -32,12 +32,12 @@ public final class PrintoutRenderer
     /**
      * Padding between the left and right of a page and the text.
      */
-    public static final int X_TEXT_MARGIN = 13;
+    public static final int X_TEXT_MARGIN = 11;
 
     /**
      * Padding between the top and bottom of a page and the text.
      */
-    public static final int Y_TEXT_MARGIN = 11;
+    public static final int Y_TEXT_MARGIN = 10;
 
     /**
      * Width of the extra page texture.


### PR DESCRIPTION
Made a few fixes in this PR, mainly:
- Centred printouts a bit better.
- Printout page turning fixed, was an unreported bug.
- Custom server terminal dimensions now render on client, resolving issue #16.