### PR TITLE
Always faster and always more accurate monitor rendering with Iris.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,14 @@ repositories {
         url "https://squiddev.cc/maven"
     }
 
+    maven {
+        name = "Modrinth"
+        url = "https://api.modrinth.com/maven"
+        content {
+            includeGroup "maven.modrinth"
+        }
+    }
+
     // TODO: Limit these to a set of groups.
     maven { url "https://maven.shedaniel.me/" }
     maven { url "https://maven.terraformersmc.com/" }
@@ -99,6 +107,7 @@ dependencies {
 
     //modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-api-fabric:6.0.254-alpha"
     //modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-fabric:6.0.254-alpha"
+    modCompileOnly 'maven.modrinth:iris:1.18.x-v1.2.4'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.0'

--- a/src/main/java/dan200/computercraft/client/render/RenderTypes.java
+++ b/src/main/java/dan200/computercraft/client/render/RenderTypes.java
@@ -24,6 +24,7 @@ public class RenderTypes
 
     public static final RenderType MONITOR_TBO = Types.MONITOR_TBO;
     public static final RenderType MONITOR = RenderType.textIntensity( FONT );
+    public static final RenderType MONITOR_POLYGON_OFFSET = RenderType.textIntensityPolygonOffset( FONT );
 
     public static final RenderType ITEM_POCKET_TERMINAL = RenderType.textIntensity( FONT );
     public static final RenderType ITEM_POCKET_LIGHT = RenderType.textIntensity( FONT );

--- a/src/main/java/dan200/computercraft/client/render/RenderTypes.java
+++ b/src/main/java/dan200/computercraft/client/render/RenderTypes.java
@@ -24,7 +24,6 @@ public class RenderTypes
 
     public static final RenderType MONITOR_TBO = Types.MONITOR_TBO;
     public static final RenderType MONITOR = RenderType.textIntensity( FONT );
-    public static final RenderType MONITOR_POLYGON_OFFSET = RenderType.textIntensityPolygonOffset( FONT );
 
     public static final RenderType ITEM_POCKET_TERMINAL = RenderType.textIntensity( FONT );
     public static final RenderType ITEM_POCKET_LIGHT = RenderType.textIntensity( FONT );

--- a/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
@@ -19,6 +19,7 @@ import dan200.computercraft.client.render.text.DirectFixedWidthFontRenderer;
 import dan200.computercraft.client.render.text.FixedWidthFontRenderer;
 import dan200.computercraft.client.util.DirectBuffers;
 import dan200.computercraft.core.terminal.Terminal;
+import dan200.computercraft.shared.integration.IrisCompat;
 import dan200.computercraft.shared.peripheral.monitor.ClientMonitor;
 import dan200.computercraft.shared.peripheral.monitor.MonitorRenderer;
 import dan200.computercraft.shared.peripheral.monitor.TileMonitor;
@@ -111,7 +112,7 @@ public class TileEntityMonitorRenderer implements BlockEntityRenderer<TileMonito
 
         // Draw the contents
         Terminal terminal = originTerminal.getTerminal();
-        if( terminal != null )
+        if( terminal != null && !IrisCompat.INSTANCE.isRenderingShadowPass() )
         {
             // Draw a terminal
             int width = terminal.getWidth(), height = terminal.getHeight();

--- a/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
@@ -180,6 +180,9 @@ public class TileEntityMonitorRenderer implements BlockEntityRenderer<TileMonito
                 tboVertex( buffer, matrix, pixelWidth + xMargin, -yMargin );
                 tboVertex( buffer, matrix, pixelWidth + xMargin, pixelHeight + yMargin );
 
+                // Force a flush of the buffer. WorldRenderer.updateCameraAndRender will "finish" all the built-in buffers
+                // before calling renderer.finish, which means our TBO quad won't be rendered yet!
+                bufferSource.getBuffer( RenderType.solid() );
                 break;
             }
 
@@ -254,10 +257,6 @@ public class TileEntityMonitorRenderer implements BlockEntityRenderer<TileMonito
                 break;
             }
         }
-
-        // Force a flush of the buffer. WorldRenderer.updateCameraAndRender will "finish" all the built-in buffers
-        // before calling renderer.finish, which means our TBO quad or depth blocker won't be rendered yet!
-        bufferSource.getBuffer( RenderType.solid() );
     }
 
     private static void tboVertex( VertexConsumer builder, Matrix4f matrix, float x, float y )

--- a/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
@@ -228,22 +228,27 @@ public class TileEntityMonitorRenderer implements BlockEntityRenderer<TileMonito
                     matrix = modelViewMatrix;
                 }
 
-                // Render background geometry
+                // Setup state
                 RenderTypes.MONITOR.setupRenderState();
-                vbo.drawWithShader(
-                    matrix, RenderSystem.getProjectionMatrix(), RenderTypes.getMonitorShader(), monitor.backgroundVertexCount, 0
-                );
+                vbo.begin( matrix, RenderSystem.getProjectionMatrix(), RenderTypes.getMonitorShader() );
 
-                // Render foreground geometry with glPolygonOffset enabled. Note we don't care about drawing these in
-                // front to back order because it's a cutout type shader that uses discard.
-                RenderTypes.MONITOR_POLYGON_OFFSET.setupRenderState();
-                vbo.drawWithShader(
-                    matrix, RenderSystem.getProjectionMatrix(), RenderTypes.getMonitorShader(),
+                // Render background geometry
+                vbo.draw( monitor.backgroundVertexCount, 0 );
+
+                // Render foreground geometry with glPolygonOffset enabled.
+                GL11.glPolygonOffset( -1.0f, -10.0f );
+                GL11.glEnable( GL11.GL_POLYGON_OFFSET_FILL );
+                vbo.draw(
                     // As mentioned in an above comment, render the extra cursor quad if it is visible this frame.
                     FixedWidthFontRenderer.isCursorVisible( terminal ) && FrameInfo.getGlobalCursorBlink() ? monitor.foregroundVertexCount + 4 : monitor.foregroundVertexCount,
                     monitor.backgroundVertexCount
                 );
-                RenderTypes.MONITOR_POLYGON_OFFSET.clearRenderState();
+
+                // Clear state
+                GL11.glPolygonOffset( 0.0f, -0.0f );
+                GL11.glDisable( GL11.GL_POLYGON_OFFSET_FILL );
+                vbo.end();
+                RenderTypes.MONITOR.clearRenderState();
 
                 RenderSystem.setInverseViewRotationMatrix( popViewRotation );
                 break;

--- a/src/main/java/dan200/computercraft/client/render/text/DirectFixedWidthFontRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/text/DirectFixedWidthFontRenderer.java
@@ -170,11 +170,11 @@ public final class DirectFixedWidthFontRenderer
         float topMarginSize, float bottomMarginSize, float leftMarginSize, float rightMarginSize
     )
     {
-        drawTerminalForeground(
+        drawTerminalBackground(
             buffer, x, y, terminal, greyscale,
             topMarginSize, bottomMarginSize, leftMarginSize, rightMarginSize
         );
-        drawTerminalBackground(
+        drawTerminalForeground(
             buffer, x, y, terminal, greyscale,
             topMarginSize, bottomMarginSize, leftMarginSize, rightMarginSize
         );
@@ -189,9 +189,9 @@ public final class DirectFixedWidthFontRenderer
         }
     }
 
-    public static int getLayerVertexCount( Terminal terminal )
+    public static int getVertexCount( Terminal terminal )
     {
-        return (terminal.getHeight() + 2) * (terminal.getWidth() + 2) * 4;
+        return (terminal.getHeight() + 2) * (terminal.getWidth() + 2) * 2 * 4;
     }
 
     private static void quad( ByteBuffer buffer, float x1, float y1, float x2, float y2, float z, byte[] rgba, float u1, float v1, float u2, float v2 )

--- a/src/main/java/dan200/computercraft/client/render/text/DirectFixedWidthFontRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/text/DirectFixedWidthFontRenderer.java
@@ -55,7 +55,7 @@ public final class DirectFixedWidthFontRenderer
         int yStart = 1 + row * (FONT_HEIGHT + 2);
 
         quad(
-            buffer, x, y, x + FONT_WIDTH, y + FONT_HEIGHT, Z_EPSILON, colour,
+            buffer, x, y, x + FONT_WIDTH, y + FONT_HEIGHT, 0f, colour,
             xStart / WIDTH, yStart / WIDTH, (xStart + FONT_WIDTH) / WIDTH, (yStart + FONT_HEIGHT) / WIDTH
         );
     }
@@ -116,7 +116,26 @@ public final class DirectFixedWidthFontRenderer
         }
     }
 
-    public static void drawTerminalWithoutCursor(
+    public static void drawTerminalForeground(
+        @Nonnull ByteBuffer buffer, float x, float y, @Nonnull Terminal terminal, boolean greyscale,
+        float topMarginSize, float bottomMarginSize, float leftMarginSize, float rightMarginSize
+    )
+    {
+        Palette palette = terminal.getPalette();
+        int height = terminal.getHeight();
+
+        // The main text
+        for( int i = 0; i < height; i++ )
+        {
+            float rowY = y + FONT_HEIGHT * i;
+            drawString(
+                buffer, x, rowY, terminal.getLine( i ), terminal.getTextColourLine( i ),
+                palette, greyscale
+            );
+        }
+    }
+
+    public static void drawTerminalBackground(
         @Nonnull ByteBuffer buffer, float x, float y, @Nonnull Terminal terminal, boolean greyscale,
         float topMarginSize, float bottomMarginSize, float leftMarginSize, float rightMarginSize
     )
@@ -143,11 +162,22 @@ public final class DirectFixedWidthFontRenderer
                 buffer, x, rowY, terminal.getBackgroundColourLine( i ), palette, greyscale,
                 leftMarginSize, rightMarginSize, FONT_HEIGHT
             );
-            drawString(
-                buffer, x, rowY, terminal.getLine( i ), terminal.getTextColourLine( i ),
-                palette, greyscale
-            );
         }
+    }
+
+    public static void drawTerminalWithoutCursor(
+        @Nonnull ByteBuffer buffer, float x, float y, @Nonnull Terminal terminal, boolean greyscale,
+        float topMarginSize, float bottomMarginSize, float leftMarginSize, float rightMarginSize
+    )
+    {
+        drawTerminalForeground(
+            buffer, x, y, terminal, greyscale,
+            topMarginSize, bottomMarginSize, leftMarginSize, rightMarginSize
+        );
+        drawTerminalBackground(
+            buffer, x, y, terminal, greyscale,
+            topMarginSize, bottomMarginSize, leftMarginSize, rightMarginSize
+        );
     }
 
     public static void drawCursor( @Nonnull ByteBuffer buffer, float x, float y, @Nonnull Terminal terminal, boolean greyscale )
@@ -159,9 +189,9 @@ public final class DirectFixedWidthFontRenderer
         }
     }
 
-    public static int getVertexCount( Terminal terminal )
+    public static int getLayerVertexCount( Terminal terminal )
     {
-        return (1 + (terminal.getHeight() + 2) * terminal.getWidth() * 2) * 4;
+        return (terminal.getHeight() + 2) * (terminal.getWidth() + 2) * 4;
     }
 
     private static void quad( ByteBuffer buffer, float x1, float y1, float x2, float y2, float z, byte[] rgba, float u1, float v1, float u2, float v2 )

--- a/src/main/java/dan200/computercraft/client/render/text/FixedWidthFontRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/text/FixedWidthFontRenderer.java
@@ -151,9 +151,27 @@ public final class FixedWidthFontRenderer
 
     }
 
-    public static void drawTerminalWithoutCursor(
-        @Nonnull QuadEmitter emitter, float x, float y,
-        @Nonnull Terminal terminal, boolean greyscale,
+    public static void drawTerminalForeground(
+        @Nonnull QuadEmitter emitter, float x, float y, @Nonnull Terminal terminal, boolean greyscale,
+        float topMarginSize, float bottomMarginSize, float leftMarginSize, float rightMarginSize
+    )
+    {
+        Palette palette = terminal.getPalette();
+        int height = terminal.getHeight();
+
+        // The main text
+        for( int i = 0; i < height; i++ )
+        {
+            float rowY = y + FONT_HEIGHT * i;
+            drawString(
+                emitter, x, rowY, terminal.getLine( i ), terminal.getTextColourLine( i ),
+                palette, greyscale, FULL_BRIGHT_LIGHTMAP
+            );
+        }
+    }
+
+    public static void drawTerminalBackground(
+        @Nonnull QuadEmitter emitter, float x, float y, @Nonnull Terminal terminal, boolean greyscale,
         float topMarginSize, float bottomMarginSize, float leftMarginSize, float rightMarginSize
     )
     {
@@ -174,16 +192,27 @@ public final class FixedWidthFontRenderer
         // The main text
         for( int i = 0; i < height; i++ )
         {
-            float rowY = y + FixedWidthFontRenderer.FONT_HEIGHT * i;
+            float rowY = y + FONT_HEIGHT * i;
             drawBackground(
                 emitter, x, rowY, terminal.getBackgroundColourLine( i ), palette, greyscale,
                 leftMarginSize, rightMarginSize, FONT_HEIGHT, FULL_BRIGHT_LIGHTMAP
             );
-            drawString(
-                emitter, x, rowY, terminal.getLine( i ), terminal.getTextColourLine( i ),
-                palette, greyscale, FULL_BRIGHT_LIGHTMAP
-            );
         }
+    }
+
+    public static void drawTerminalWithoutCursor(
+        @Nonnull QuadEmitter emitter, float x, float y, @Nonnull Terminal terminal, boolean greyscale,
+        float topMarginSize, float bottomMarginSize, float leftMarginSize, float rightMarginSize
+    )
+    {
+        drawTerminalForeground(
+            emitter, x, y, terminal, greyscale,
+            topMarginSize, bottomMarginSize, leftMarginSize, rightMarginSize
+        );
+        drawTerminalBackground(
+            emitter, x, y, terminal, greyscale,
+            topMarginSize, bottomMarginSize, leftMarginSize, rightMarginSize
+        );
     }
 
     public static boolean isCursorVisible( Terminal terminal )

--- a/src/main/java/dan200/computercraft/client/util/DirectVertexBuffer.java
+++ b/src/main/java/dan200/computercraft/client/util/DirectVertexBuffer.java
@@ -5,13 +5,16 @@
  */
 package dan200.computercraft.client.util;
 
+import com.mojang.blaze3d.platform.Window;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.BufferUploader;
 import com.mojang.blaze3d.vertex.VertexBuffer;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.math.Matrix4f;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ShaderInstance;
 import org.lwjgl.opengl.GL15;
+import org.lwjgl.opengl.GL32;
 import org.lwjgl.opengl.GL45C;
 
 import java.nio.ByteBuffer;
@@ -48,11 +51,85 @@ public class DirectVertexBuffer extends VertexBuffer
         sequentialIndices = true;
     }
 
-    public void drawWithShader( Matrix4f modelView, Matrix4f projection, ShaderInstance shader, int indexCount )
+    public void drawWithShader( Matrix4f modelView, Matrix4f projection, ShaderInstance shader, int vertexCount, int baseVertex )
     {
-        this.indexCount = indexCount;
-        drawWithShader( modelView, projection, shader );
-        this.indexCount = actualIndexCount;
+        indexCount = mode.indexCount( vertexCount );
+        drawWithShaderBaseVertex( modelView, projection, shader, baseVertex );
+        indexCount = actualIndexCount;
+    }
+
+    private void drawWithShaderBaseVertex( Matrix4f matrix4f, Matrix4f matrix4f2, ShaderInstance shaderInstance, int baseVertex )
+    {
+        if ( indexCount == 0 )
+        {
+            return;
+        }
+        RenderSystem.assertOnRenderThread();
+        BufferUploader.reset();
+        for ( int i = 0; i < 12; ++i )
+        {
+            int j = RenderSystem.getShaderTexture( i );
+            shaderInstance.setSampler( "Sampler" + i, j );
+        }
+        if ( shaderInstance.MODEL_VIEW_MATRIX != null )
+        {
+            shaderInstance.MODEL_VIEW_MATRIX.set( matrix4f );
+        }
+        if ( shaderInstance.PROJECTION_MATRIX != null )
+        {
+            shaderInstance.PROJECTION_MATRIX.set( matrix4f2 );
+        }
+        if ( shaderInstance.INVERSE_VIEW_ROTATION_MATRIX != null )
+        {
+            shaderInstance.INVERSE_VIEW_ROTATION_MATRIX.set( RenderSystem.getInverseViewRotationMatrix() );
+        }
+        if ( shaderInstance.COLOR_MODULATOR != null )
+        {
+            shaderInstance.COLOR_MODULATOR.set( RenderSystem.getShaderColor() );
+        }
+        if ( shaderInstance.FOG_START != null )
+        {
+            shaderInstance.FOG_START.set( RenderSystem.getShaderFogStart() );
+        }
+        if ( shaderInstance.FOG_END != null )
+        {
+            shaderInstance.FOG_END.set( RenderSystem.getShaderFogEnd() );
+        }
+        if ( shaderInstance.FOG_COLOR != null )
+        {
+            shaderInstance.FOG_COLOR.set( RenderSystem.getShaderFogColor() );
+        }
+        if ( shaderInstance.FOG_SHAPE != null )
+        {
+            shaderInstance.FOG_SHAPE.set( RenderSystem.getShaderFogShape().getIndex() );
+        }
+        if ( shaderInstance.TEXTURE_MATRIX != null )
+        {
+            shaderInstance.TEXTURE_MATRIX.set( RenderSystem.getTextureMatrix() );
+        }
+        if ( shaderInstance.GAME_TIME != null )
+        {
+            shaderInstance.GAME_TIME.set( RenderSystem.getShaderGameTime() );
+        }
+        if ( shaderInstance.SCREEN_SIZE != null )
+        {
+            Window window = Minecraft.getInstance().getWindow();
+            shaderInstance.SCREEN_SIZE.set( (float)window.getWidth(), (float)window.getHeight() );
+        }
+        if ( shaderInstance.LINE_WIDTH != null && (mode == VertexFormat.Mode.LINES || mode == VertexFormat.Mode.LINE_STRIP) )
+        {
+            shaderInstance.LINE_WIDTH.set( RenderSystem.getShaderLineWidth() );
+        }
+        RenderSystem.setupShaderLights( shaderInstance );
+        bindVertexArray();
+        bind();
+        getFormat().setupBufferState();
+        shaderInstance.apply();
+        GL32.glDrawElementsBaseVertex( mode.asGLMode, indexCount, indexType.asGLType, 0L, baseVertex );
+        shaderInstance.clear();
+        getFormat().clearBufferState();
+        VertexBuffer.unbind();
+        VertexBuffer.unbindVertexArray();
     }
 
     public int getIndexCount()

--- a/src/main/java/dan200/computercraft/shared/integration/IrisCompat.java
+++ b/src/main/java/dan200/computercraft/shared/integration/IrisCompat.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of ComputerCraft - http://www.computercraft.info
+ * Copyright Daniel Ratcliffe, 2011-2022. Do not distribute without permission.
+ * Send enquiries to dratcliffe@gmail.com
+ */
+package dan200.computercraft.shared.integration;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.irisshaders.iris.api.v0.IrisApi;
+
+public class IrisCompat
+{
+    public static final IrisCompat INSTANCE = FabricLoader.getInstance().isModLoaded( "iris" ) ? new Impl() : new IrisCompat();
+
+    public boolean isRenderingShadowPass()
+    {
+        return false;
+    }
+
+    private static class Impl extends IrisCompat
+    {
+        @Override
+        public boolean isRenderingShadowPass()
+        {
+            return IrisApi.getInstance().isRenderingShadowPass();
+        }
+    }
+}

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/ClientMonitor.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/ClientMonitor.java
@@ -33,8 +33,9 @@ public final class ClientMonitor extends ClientTerminal
     public int tboBuffer;
     public int tboTexture;
     public int tboUniform;
-    public DirectVertexBuffer backgroundBuffer;
-    public DirectVertexBuffer foregroundBuffer;
+    public DirectVertexBuffer buffer;
+    public int backgroundVertexCount;
+    public int foregroundVertexCount;
 
     public ClientMonitor( boolean colour, TileMonitor origin )
     {
@@ -80,11 +81,10 @@ public final class ClientMonitor extends ClientTerminal
             }
 
             case VBO:
-                if( backgroundBuffer != null && foregroundBuffer != null ) return false;
+                if( buffer != null ) return false;
 
                 deleteBuffers();
-                backgroundBuffer = new DirectVertexBuffer();
-                foregroundBuffer = new DirectVertexBuffer();
+                buffer = new DirectVertexBuffer();
                 addMonitor();
                 return true;
 
@@ -122,23 +122,20 @@ public final class ClientMonitor extends ClientTerminal
             tboUniform = 0;
         }
 
-        if( foregroundBuffer != null )
+        if( buffer != null )
         {
-            foregroundBuffer.close();
-            foregroundBuffer = null;
+            buffer.close();
+            buffer = null;
         }
 
-        if( backgroundBuffer != null )
-        {
-            backgroundBuffer.close();
-            backgroundBuffer = null;
-        }
+        backgroundVertexCount = 0;
+        foregroundVertexCount = 0;
     }
 
     @Environment( EnvType.CLIENT )
     public void destroy()
     {
-        if( tboBuffer != 0 || backgroundBuffer != null || foregroundBuffer != null )
+        if( tboBuffer != 0 || buffer != null )
         {
             synchronized( allMonitors )
             {

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/ClientMonitor.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/ClientMonitor.java
@@ -33,7 +33,8 @@ public final class ClientMonitor extends ClientTerminal
     public int tboBuffer;
     public int tboTexture;
     public int tboUniform;
-    public DirectVertexBuffer buffer;
+    public DirectVertexBuffer backgroundBuffer;
+    public DirectVertexBuffer foregroundBuffer;
 
     public ClientMonitor( boolean colour, TileMonitor origin )
     {
@@ -79,10 +80,11 @@ public final class ClientMonitor extends ClientTerminal
             }
 
             case VBO:
-                if( buffer != null ) return false;
+                if( backgroundBuffer != null && foregroundBuffer != null ) return false;
 
                 deleteBuffers();
-                buffer = new DirectVertexBuffer();
+                backgroundBuffer = new DirectVertexBuffer();
+                foregroundBuffer = new DirectVertexBuffer();
                 addMonitor();
                 return true;
 
@@ -120,17 +122,23 @@ public final class ClientMonitor extends ClientTerminal
             tboUniform = 0;
         }
 
-        if( buffer != null )
+        if( foregroundBuffer != null )
         {
-            buffer.close();
-            buffer = null;
+            foregroundBuffer.close();
+            foregroundBuffer = null;
+        }
+
+        if( backgroundBuffer != null )
+        {
+            backgroundBuffer.close();
+            backgroundBuffer = null;
         }
     }
 
     @Environment( EnvType.CLIENT )
     public void destroy()
     {
-        if( tboBuffer != 0 || buffer != null )
+        if( tboBuffer != 0 || backgroundBuffer != null || foregroundBuffer != null )
         {
             synchronized( allMonitors )
             {

--- a/src/main/resources/cc.accesswidener
+++ b/src/main/resources/cc.accesswidener
@@ -6,12 +6,3 @@ accessible method net/minecraft/client/renderer/RenderType create (Ljava/lang/St
 # SpeakerInstance/SpeakerManager
 accessible method com/mojang/blaze3d/audio/Channel pumpBuffers (I)V
 accessible field net/minecraft/client/sounds/SoundEngine executor Lnet/minecraft/client/sounds/SoundEngineExecutor;
-
-# DirectVertexBuffer
-accessible field com/mojang/blaze3d/vertex/VertexBuffer vertextBufferId I
-accessible field com/mojang/blaze3d/vertex/VertexBuffer indexType Lcom/mojang/blaze3d/vertex/VertexFormat$IndexType;
-accessible field com/mojang/blaze3d/vertex/VertexBuffer indexCount I
-accessible field com/mojang/blaze3d/vertex/VertexBuffer mode Lcom/mojang/blaze3d/vertex/VertexFormat$Mode;
-accessible field com/mojang/blaze3d/vertex/VertexBuffer sequentialIndices Z
-accessible field com/mojang/blaze3d/vertex/VertexBuffer format Lcom/mojang/blaze3d/vertex/VertexFormat;
-accessible method com/mojang/blaze3d/vertex/VertexBuffer bindVertexArray ()V

--- a/src/main/resources/cc.accesswidener
+++ b/src/main/resources/cc.accesswidener
@@ -14,3 +14,4 @@ accessible field com/mojang/blaze3d/vertex/VertexBuffer indexCount I
 accessible field com/mojang/blaze3d/vertex/VertexBuffer mode Lcom/mojang/blaze3d/vertex/VertexFormat$Mode;
 accessible field com/mojang/blaze3d/vertex/VertexBuffer sequentialIndices Z
 accessible field com/mojang/blaze3d/vertex/VertexBuffer format Lcom/mojang/blaze3d/vertex/VertexFormat;
+accessible method com/mojang/blaze3d/vertex/VertexBuffer bindVertexArray ()V


### PR DESCRIPTION
Depends on #96. Merge that first.

- In order to fix a slight visual artifact caused by using a z-offset on monitors, I split the terminal geometry into a foreground and background VBO and made the foreground render with glPolygonOffset. This effectively makes everything in plane without z-fighting. Having two VBOs does slow things down a little bit.
- To speed things back up I added an Iris integration so we can detect when we're in the shadow pass and use simplified geometry. This can double frame rates when rendering really complex monitor geometry.
