### PR TITLE
Provide fix for #87

### DIFF
--- a/src/main/java/dan200/computercraft/shared/turtle/blocks/TileTurtle.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/blocks/TileTurtle.java
@@ -432,11 +432,12 @@ public class TileTurtle extends TileComputerBase implements ITurtleTile, Default
     @Override
     public void setItem( int i, @Nonnull ItemStack stack )
     {
-        if( i >= 0 && i < INVENTORY_SIZE && !InventoryUtil.areItemsEqual( stack, inventory.get( i ) ) )
-        {
-            inventory.set( i, stack );
-            onInventoryDefinitelyChanged();
-        }
+            if ( i >= 0 && i < INVENTORY_SIZE )
+            {
+                inventory.set(i, stack);
+                if ( !InventoryUtil.areItemsEqual(stack, inventory.get(i)) )
+                    onInventoryDefinitelyChanged();
+            }
     }
 
     @Override

--- a/src/main/java/dan200/computercraft/shared/turtle/blocks/TileTurtle.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/blocks/TileTurtle.java
@@ -432,12 +432,14 @@ public class TileTurtle extends TileComputerBase implements ITurtleTile, Default
     @Override
     public void setItem( int i, @Nonnull ItemStack stack )
     {
-            if ( i >= 0 && i < INVENTORY_SIZE )
+        if ( i >= 0 && i < INVENTORY_SIZE )
+        {
+            inventory.set( i, stack );
+            if ( !InventoryUtil.areItemsEqual( stack, inventory.get( i ) ) )
             {
-                inventory.set(i, stack);
-                if ( !InventoryUtil.areItemsEqual(stack, inventory.get(i)) )
-                    onInventoryDefinitelyChanged();
+                onInventoryDefinitelyChanged();
             }
+        }
     }
 
     @Override


### PR DESCRIPTION
Should fix #87

Why? I guess, because transfer API internally inserting a copy of real itemStack and then perform some tricks. And if we ignore this insertions, we receive voiding of real itemStack (because then transfer API mutate this stack)
