### PR TITLE
Add support for Iris's new text sink API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,13 @@ dependencies {
 
     //modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-api-fabric:6.0.254-alpha"
     //modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-fabric:6.0.254-alpha"
-    modCompileOnly 'maven.modrinth:iris:1.18.x-v1.2.4'
+
+    modCompileOnly "maven.modrinth:iris:1.18.x-v1.2.5"
+
+    // For running with Iris. Can be ignored most of the time.
+    // modCompileOnly "maven.modrinth:sodium:mc1.18.2-0.4.1"
+    // runtimeOnly "org.joml:joml:1.10.2"
+    // runtimeOnly "org.anarres:jcpp:1.4.14"
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.0'

--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     modCompileOnly "maven.modrinth:iris:1.18.x-v1.2.5"
 
     // For running with Iris. Can be ignored most of the time.
-    // modCompileOnly "maven.modrinth:sodium:mc1.18.2-0.4.1"
+    // modRuntimeOnly "maven.modrinth:sodium:mc1.18.2-0.4.1"
     // runtimeOnly "org.joml:joml:1.10.2"
     // runtimeOnly "org.anarres:jcpp:1.4.14"
 

--- a/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
+++ b/src/main/java/dan200/computercraft/client/render/TileEntityMonitorRenderer.java
@@ -200,18 +200,17 @@ public class TileEntityMonitorRenderer implements BlockEntityRenderer<TileMonito
                     var buffer = sink.buffer();
 
                     DirectFixedWidthFontRenderer.drawTerminalBackground( sink, 0, 0, terminal, !monitor.isColour(), yMargin, yMargin, xMargin, xMargin );
-                    int backgroundBytes = buffer.position();
+                    monitor.backgroundVertexCount = buffer.position() / vertexSize;
+
                     DirectFixedWidthFontRenderer.drawTerminalForeground( sink, 0, 0, terminal, !monitor.isColour(), yMargin, yMargin, xMargin, xMargin );
-                    int termVertices = buffer.position() / vertexSize;
-                    monitor.backgroundVertexCount = backgroundBytes / vertexSize;
-                    monitor.foregroundVertexCount = termVertices - monitor.backgroundVertexCount;
+                    monitor.foregroundVertexCount = (buffer.position() / vertexSize) - monitor.backgroundVertexCount;
 
                     // If the cursor is visible, we append it to the end of our buffer. When rendering, we can either
                     // render n or n+1 quads and so toggle the cursor on and off.
                     DirectFixedWidthFontRenderer.drawCursor( sink, 0, 0, terminal, !monitor.isColour() );
 
                     buffer.flip();
-                    vbo.upload( buffer.position() / vertexSize, RenderTypes.MONITOR.mode(), sink.getFormat(), buffer );
+                    vbo.upload( buffer.limit() / vertexSize, RenderTypes.MONITOR.mode(), sink.getFormat(), buffer );
                 }
 
                 // TODO Figure out how to setup the inverse view rotation matrix properly.

--- a/src/main/java/dan200/computercraft/client/util/DirectVertexBuffer.java
+++ b/src/main/java/dan200/computercraft/client/util/DirectVertexBuffer.java
@@ -29,8 +29,7 @@ public class DirectVertexBuffer
     private VertexFormat.Mode mode;
     private VertexFormat format;
 
-    private int vertexCount;
-    private VertexFormat.IndexType indexType;
+    private RenderSystem.AutoStorageIndexBuffer indexBuffer;
 
     private ShaderInstance currentShader;
     private boolean vaoInitialised;
@@ -47,7 +46,8 @@ public class DirectVertexBuffer
 
         this.format = format;
         this.mode = mode;
-        this.vertexCount = vertexCount;
+        indexBuffer = RenderSystem.getSequentialBuffer( mode, mode.indexCount( vertexCount ) );
+
         vaoInitialised = false;
     }
 
@@ -71,9 +71,7 @@ public class DirectVertexBuffer
             GL32C.glBindBuffer( GL32C.GL_ARRAY_BUFFER, 0 );
 
             // Bind index buffer (this binding is kept in the VAO state!).
-            RenderSystem.AutoStorageIndexBuffer autoStorageIndexBuffer = RenderSystem.getSequentialBuffer( mode, mode.indexCount( vertexCount ) );
-            indexType = autoStorageIndexBuffer.type();
-            GL32C.glBindBuffer( GL32C.GL_ELEMENT_ARRAY_BUFFER, autoStorageIndexBuffer.name() );
+            GL32C.glBindBuffer( GL32C.GL_ELEMENT_ARRAY_BUFFER, indexBuffer.name() );
 
             vaoInitialised = true;
         }
@@ -95,7 +93,7 @@ public class DirectVertexBuffer
         if( vertexCount == 0 || currentShader == null ) return;
 
         if( vertexCount < 0 ) throw new IllegalStateException( "Rendering negative elements?" );
-        GL32C.glDrawElementsBaseVertex( mode.asGLMode, mode.indexCount( vertexCount ), indexType.asGLType, 0L, baseVertex );
+        GL32C.glDrawElementsBaseVertex( mode.asGLMode, mode.indexCount( vertexCount ), indexBuffer.type().asGLType, 0L, baseVertex );
     }
 
     private void bindVertexArray()

--- a/src/main/java/dan200/computercraft/client/util/DirectVertexBuffer.java
+++ b/src/main/java/dan200/computercraft/client/util/DirectVertexBuffer.java
@@ -55,9 +55,9 @@ public class DirectVertexBuffer
      * Call this method before calling {@link DirectVertexBuffer#draw(int, int)}. When done drawing out of the vbo, make
      * sure to call {@link DirectVertexBuffer#end()}!
      *
-     * @param modelView The modelView matrix.
+     * @param modelView  The modelView matrix.
      * @param projection The projection matrix.
-     * @param shader The shader to use for this series of draws.
+     * @param shader     The shader to use for this series of draws.
      */
     public void begin( Matrix4f modelView, Matrix4f projection, ShaderInstance shader )
     {
@@ -92,8 +92,9 @@ public class DirectVertexBuffer
 
     public void draw( int vertexCount, int baseVertex )
     {
-        if ( vertexCount == 0 || currentShader == null ) return;
+        if( vertexCount == 0 || currentShader == null ) return;
 
+        if( vertexCount < 0 ) throw new IllegalStateException( "Rendering negative elements?" );
         GL32C.glDrawElementsBaseVertex( mode.asGLMode, mode.indexCount( vertexCount ), indexType.asGLType, 0L, baseVertex );
     }
 
@@ -123,57 +124,30 @@ public class DirectVertexBuffer
 
     private void setupShader( ShaderInstance shader, Matrix4f modelView, Matrix4f projection )
     {
-        for ( int i = 0; i < 12; ++i )
+        for( int i = 0; i < 12; ++i )
         {
             int j = RenderSystem.getShaderTexture( i );
             shader.setSampler( "Sampler" + i, j );
         }
-        if ( shader.MODEL_VIEW_MATRIX != null )
-        {
-            shader.MODEL_VIEW_MATRIX.set( modelView );
-        }
-        if ( shader.PROJECTION_MATRIX != null )
-        {
-            shader.PROJECTION_MATRIX.set( projection );
-        }
-        if ( shader.INVERSE_VIEW_ROTATION_MATRIX != null )
+        if( shader.MODEL_VIEW_MATRIX != null ) shader.MODEL_VIEW_MATRIX.set( modelView );
+        if( shader.PROJECTION_MATRIX != null ) shader.PROJECTION_MATRIX.set( projection );
+        if( shader.INVERSE_VIEW_ROTATION_MATRIX != null )
         {
             shader.INVERSE_VIEW_ROTATION_MATRIX.set( RenderSystem.getInverseViewRotationMatrix() );
         }
-        if ( shader.COLOR_MODULATOR != null )
-        {
-            shader.COLOR_MODULATOR.set( RenderSystem.getShaderColor() );
-        }
-        if ( shader.FOG_START != null )
-        {
-            shader.FOG_START.set( RenderSystem.getShaderFogStart() );
-        }
-        if ( shader.FOG_END != null )
-        {
-            shader.FOG_END.set( RenderSystem.getShaderFogEnd() );
-        }
-        if ( shader.FOG_COLOR != null )
-        {
-            shader.FOG_COLOR.set( RenderSystem.getShaderFogColor() );
-        }
-        if ( shader.FOG_SHAPE != null )
-        {
-            shader.FOG_SHAPE.set( RenderSystem.getShaderFogShape().getIndex() );
-        }
-        if ( shader.TEXTURE_MATRIX != null )
-        {
-            shader.TEXTURE_MATRIX.set( RenderSystem.getTextureMatrix() );
-        }
-        if ( shader.GAME_TIME != null )
-        {
-            shader.GAME_TIME.set( RenderSystem.getShaderGameTime() );
-        }
-        if ( shader.SCREEN_SIZE != null )
+        if( shader.COLOR_MODULATOR != null ) shader.COLOR_MODULATOR.set( RenderSystem.getShaderColor() );
+        if( shader.FOG_START != null ) shader.FOG_START.set( RenderSystem.getShaderFogStart() );
+        if( shader.FOG_END != null ) shader.FOG_END.set( RenderSystem.getShaderFogEnd() );
+        if( shader.FOG_COLOR != null ) shader.FOG_COLOR.set( RenderSystem.getShaderFogColor() );
+        if( shader.FOG_SHAPE != null ) shader.FOG_SHAPE.set( RenderSystem.getShaderFogShape().getIndex() );
+        if( shader.TEXTURE_MATRIX != null ) shader.TEXTURE_MATRIX.set( RenderSystem.getTextureMatrix() );
+        if( shader.GAME_TIME != null ) shader.GAME_TIME.set( RenderSystem.getShaderGameTime() );
+        if( shader.SCREEN_SIZE != null )
         {
             Window window = Minecraft.getInstance().getWindow();
             shader.SCREEN_SIZE.set( window.getWidth(), window.getHeight() );
         }
-        if ( shader.LINE_WIDTH != null && (mode == VertexFormat.Mode.LINES || mode == VertexFormat.Mode.LINE_STRIP) )
+        if( shader.LINE_WIDTH != null && (mode == VertexFormat.Mode.LINES || mode == VertexFormat.Mode.LINE_STRIP) )
         {
             shader.LINE_WIDTH.set( RenderSystem.getShaderLineWidth() );
         }

--- a/src/main/java/dan200/computercraft/client/util/DirectVertexBuffer.java
+++ b/src/main/java/dan200/computercraft/client/util/DirectVertexBuffer.java
@@ -92,7 +92,6 @@ public class DirectVertexBuffer
     {
         if( vertexCount == 0 || currentShader == null ) return;
 
-        if( vertexCount < 0 ) throw new IllegalStateException( "Rendering negative elements?" );
         GL32C.glDrawElementsBaseVertex( mode.asGLMode, mode.indexCount( vertexCount ), indexBuffer.type().asGLType, 0L, baseVertex );
     }
 

--- a/src/main/java/dan200/computercraft/shared/integration/IrisCompat.java
+++ b/src/main/java/dan200/computercraft/shared/integration/IrisCompat.java
@@ -5,8 +5,15 @@
  */
 package dan200.computercraft.shared.integration;
 
+import com.mojang.blaze3d.vertex.VertexFormat;
+import dan200.computercraft.client.render.RenderTypes;
+import dan200.computercraft.client.render.text.DirectFixedWidthFontRenderer;
 import net.fabricmc.loader.api.FabricLoader;
 import net.irisshaders.iris.api.v0.IrisApi;
+import net.irisshaders.iris.api.v0.IrisTextVertexSink;
+
+import java.nio.ByteBuffer;
+import java.util.function.IntFunction;
 
 public class IrisCompat
 {
@@ -17,12 +24,60 @@ public class IrisCompat
         return false;
     }
 
+    public DirectFixedWidthFontRenderer.QuadSink getVertexSink( int vertexCount, IntFunction<ByteBuffer> makeBuffer )
+    {
+        return new DirectFixedWidthFontRenderer.ByteBufferSink(
+            makeBuffer.apply( RenderTypes.MONITOR.format().getVertexSize() * vertexCount * 4 )
+        );
+    }
+
     private static class Impl extends IrisCompat
     {
         @Override
         public boolean isRenderingShadowPass()
         {
             return IrisApi.getInstance().isRenderingShadowPass();
+        }
+
+        @Override
+        public DirectFixedWidthFontRenderer.QuadSink getVertexSink( int vertexCount, IntFunction<ByteBuffer> makeBuffer )
+        {
+            return IrisApi.getInstance().getMinorApiRevision() >= 1
+                ? new IrisQuadSink( vertexCount, makeBuffer )
+                : super.getVertexSink( vertexCount, makeBuffer );
+        }
+    }
+
+    private static final class IrisQuadSink implements DirectFixedWidthFontRenderer.QuadSink
+    {
+        private final IrisTextVertexSink sink;
+
+        private IrisQuadSink( int vertexCount, IntFunction<ByteBuffer> makeBuffer )
+        {
+            sink = IrisApi.getInstance().createTextVertexSink( vertexCount, makeBuffer );
+        }
+
+        @Override
+        public VertexFormat getFormat()
+        {
+            return sink.getUnderlyingVertexFormat();
+        }
+
+        @Override
+        public ByteBuffer buffer()
+        {
+            return sink.getUnderlyingByteBuffer();
+        }
+
+        @Override
+        public void quad( float x1, float y1, float x2, float y2, float z, byte[] rgba, float u1, float v1, float u2, float v2 )
+        {
+            sink.quad( x1, y1, x2, y2, z, pack( rgba[0], rgba[1], rgba[2], rgba[3] ), u1, v1, u2, v2, RenderTypes.FULL_BRIGHT_LIGHTMAP );
+        }
+
+        private static int pack( int r, int g, int b, int a )
+        {
+            return (a & 255) << 24 | (b & 255) << 16 | (g & 255) << 8 | r & 255;
         }
     }
 }


### PR DESCRIPTION
This is needed on Iris 1.2.5 as they change the vertex format of `RenderType.text`, so us chucking bytes in directly won't work!

I'd like to profile this before merging and check that the new virtual calls are JITted away, but otherwise this is good for review.

CCing @IMS212, in case they have any comments.