### PR TITLE
Make monitors cull internal faces

### DIFF
--- a/src/main/java/dan200/computercraft/shared/Registry.java
+++ b/src/main/java/dan200/computercraft/shared/Registry.java
@@ -98,10 +98,10 @@ public final class Registry
         }
 
         public static final BlockMonitor MONITOR_NORMAL =
-            register( "monitor_normal", new BlockMonitor( properties(), () -> ModBlockEntities.MONITOR_NORMAL ) );
+            register( "monitor_normal", new BlockMonitor( monitorProperties(), () -> ModBlockEntities.MONITOR_NORMAL ) );
 
         public static final BlockMonitor MONITOR_ADVANCED =
-            register( "monitor_advanced", new BlockMonitor( properties(), () -> ModBlockEntities.MONITOR_ADVANCED ) );
+            register( "monitor_advanced", new BlockMonitor( monitorProperties(), () -> ModBlockEntities.MONITOR_ADVANCED ) );
 
         public static final BlockComputer<TileComputer> COMPUTER_NORMAL =
             register( "computer_normal", new BlockComputer<>( properties(), ComputerFamily.NORMAL, () -> ModBlockEntities.COMPUTER_NORMAL ) );
@@ -142,6 +142,11 @@ public final class Registry
         private static BlockBehaviour.Properties properties()
         {
             return BlockBehaviour.Properties.of( Material.STONE ).strength( 2F ).noOcclusion();
+        }
+
+        private static BlockBehaviour.Properties monitorProperties()
+        {
+            return BlockBehaviour.Properties.of( Material.STONE ).strength( 2F );
         }
 
         private static BlockBehaviour.Properties turtleProperties()


### PR DESCRIPTION
We turned off culling to support 3prm3's cool detailed computer models. That change shouldn't have applied to monitors, which should behave as opaque full blocks. This has a performance impact in really extreme cases, but mainly it's just a small parity issue with CC: Tweaked.

There's been times where this "bug" is useful: when people send screenshots of a broken monitor you can easily tell if they're running Tweaked or Restitched. The textures usually also give it away though, so I think it's okay to fix this.
