### PR TITLE
Fix #122 by simulating inventory transactions before execution.

### DIFF
--- a/src/main/java/dan200/computercraft/shared/pocket/apis/PocketAPI.java
+++ b/src/main/java/dan200/computercraft/shared/pocket/apis/PocketAPI.java
@@ -82,7 +82,7 @@ public class PocketAPI implements ILuaAPI
             ItemStack stack = previousUpgrade.getCraftingItem();
             if( !stack.isEmpty() )
             {
-                stack = InventoryUtil.storeItems( stack, ItemStorage.wrap( inventory ), inventory.selected );
+                stack = InventoryUtil.storeItems( stack, ItemStorage.wrap( inventory ), inventory.selected, false );
                 if( !stack.isEmpty() )
                 {
                     WorldUtil.dropItemStack( stack, player.getCommandSenderWorld(), player.position() );
@@ -118,7 +118,7 @@ public class PocketAPI implements ILuaAPI
         ItemStack stack = previousUpgrade.getCraftingItem();
         if( !stack.isEmpty() )
         {
-            stack = InventoryUtil.storeItems( stack, ItemStorage.wrap( inventory ), inventory.selected );
+            stack = InventoryUtil.storeItems( stack, ItemStorage.wrap( inventory ), inventory.selected, false );
             if( stack.isEmpty() )
             {
                 WorldUtil.dropItemStack( stack, player.getCommandSenderWorld(), player.position() );

--- a/src/main/java/dan200/computercraft/shared/turtle/FurnaceRefuelHandler.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/FurnaceRefuelHandler.java
@@ -38,7 +38,7 @@ public final class FurnaceRefuelHandler implements TurtleRefuelEvent.Handler
         Item replacementStack = stack.getItem().getCraftingRemainingItem();
         if( replacementStack != null )
         {
-            ItemStack remainder = InventoryUtil.storeItems( new ItemStack( replacementStack ), turtle.getItemHandler(), turtle.getSelectedSlot() );
+            ItemStack remainder = InventoryUtil.storeItems( new ItemStack( replacementStack ), turtle.getItemHandler(), turtle.getSelectedSlot(), false );
             if( !remainder.isEmpty() )
             {
                 WorldUtil.dropItemStack( remainder, turtle.getLevel(), turtle.getPosition(), turtle.getDirection().getOpposite() );

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleCraftCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleCraftCommand.java
@@ -38,7 +38,7 @@ public class TurtleCraftCommand implements ITurtleCommand
         // Store or drop any remainders
         for( ItemStack stack : results )
         {
-            ItemStack remainder = InventoryUtil.storeItems( stack, turtle.getItemHandler(), turtle.getSelectedSlot() );
+            ItemStack remainder = InventoryUtil.storeItems( stack, turtle.getItemHandler(), turtle.getSelectedSlot(), false );
             if( !remainder.isEmpty() )
             {
                 WorldUtil.dropItemStack( remainder, turtle.getLevel(), turtle.getPosition(), turtle.getDirection() );

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleDropCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleDropCommand.java
@@ -46,7 +46,7 @@ public class TurtleDropCommand implements ITurtleCommand
         Direction direction = this.direction.toWorldDir( turtle );
 
         // Get things to drop
-        ItemStack stack = InventoryUtil.takeItems( quantity, turtle.getItemHandler(), turtle.getSelectedSlot(), 1, turtle.getSelectedSlot() );
+        ItemStack stack = InventoryUtil.takeItems( quantity, turtle.getItemHandler(), turtle.getSelectedSlot(), 1, turtle.getSelectedSlot(), false );
         if( stack.isEmpty() )
         {
             return TurtleCommandResult.failure( "No items to drop" );
@@ -63,11 +63,11 @@ public class TurtleDropCommand implements ITurtleCommand
         if( inventory != null )
         {
             // Drop the item into the inventory
-            ItemStack remainder = InventoryUtil.storeItems( stack, ItemStorage.wrap( inventory, side ) );
+            ItemStack remainder = InventoryUtil.storeItems( stack, ItemStorage.wrap( inventory, side ), false );
             if( !remainder.isEmpty() )
             {
                 // Put the remainder back in the turtle
-                InventoryUtil.storeItems( remainder, turtle.getItemHandler(), turtle.getSelectedSlot() );
+                InventoryUtil.storeItems( remainder, turtle.getItemHandler(), turtle.getSelectedSlot(), false );
             }
 
             // Return true if we stored anything

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleEquipCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleEquipCommand.java
@@ -63,12 +63,12 @@ public class TurtleEquipCommand implements ITurtleCommand
         if( newUpgradeStack != null )
         {
             // Consume new upgrades item
-            InventoryUtil.takeItems( 1, ItemStorage.wrap( inventory ), turtle.getSelectedSlot(), 1, turtle.getSelectedSlot() );
+            InventoryUtil.takeItems( 1, ItemStorage.wrap( inventory ), turtle.getSelectedSlot(), 1, turtle.getSelectedSlot(), false );
         }
         if( oldUpgradeStack != null )
         {
             // Store old upgrades item
-            ItemStack remainder = InventoryUtil.storeItems( oldUpgradeStack, ItemStorage.wrap( inventory ), turtle.getSelectedSlot() );
+            ItemStack remainder = InventoryUtil.storeItems( oldUpgradeStack, ItemStorage.wrap( inventory ), turtle.getSelectedSlot(), false );
             if( !remainder.isEmpty() )
             {
                 // If there's no room for the items, drop them

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtlePlaceCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtlePlaceCommand.java
@@ -131,7 +131,7 @@ public class TurtlePlaceCommand implements ITurtleCommand
         Vec3 hitPos = hit.getValue();
 
         ItemStorage itemHandler = ItemStorage.wrap( turtlePlayer.getInventory() );
-        DropConsumer.set( hitEntity, drop -> InventoryUtil.storeItems( drop, itemHandler, 1 ) );
+        DropConsumer.set( hitEntity, drop -> InventoryUtil.storeItems( drop, itemHandler, 1, false ) );
 
         boolean placed = doDeployOnEntity( stack, turtlePlayer, hitEntity, hitPos );
 

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtlePlayer.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtlePlayer.java
@@ -185,7 +185,7 @@ public final class TurtlePlayer extends FakePlayer
         int totalSize = getInventory().getContainerSize();
         for( int i = slots; i < totalSize; i++ )
         {
-            ItemStack remainder = InventoryUtil.storeItems( getInventory().getItem( i ), turtle.getItemHandler(), turtle.getSelectedSlot() );
+            ItemStack remainder = InventoryUtil.storeItems( getInventory().getItem( i ), turtle.getItemHandler(), turtle.getSelectedSlot(), false );
             if( !remainder.isEmpty() )
             {
                 WorldUtil.dropItemStack( remainder, turtle.getLevel(), dropPosition, dropDirection );

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleSuckCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleSuckCommand.java
@@ -61,15 +61,15 @@ public class TurtleSuckCommand implements ITurtleCommand
             ItemStorage inventory = ItemStorage.wrap( inventoryContainer );
 
             // Take from inventory of thing in front
-            ItemStack stack = InventoryUtil.takeItems( quantity, inventory );
+            ItemStack stack = InventoryUtil.takeItems( quantity, inventory, false );
             if( stack.isEmpty() ) return TurtleCommandResult.failure( "No items to take" );
 
             // Try to place into the turtle
-            ItemStack remainder = InventoryUtil.storeItems( stack, turtle.getItemHandler(), turtle.getSelectedSlot() );
+            ItemStack remainder = InventoryUtil.storeItems( stack, turtle.getItemHandler(), turtle.getSelectedSlot(), false );
             if( !remainder.isEmpty() )
             {
                 // Put the remainder back in the inventory
-                InventoryUtil.storeItems( remainder, inventory );
+                InventoryUtil.storeItems( remainder, inventory, false );
             }
 
             // Return true if we consumed anything
@@ -111,7 +111,7 @@ public class TurtleSuckCommand implements ITurtleCommand
                     leaveStack = ItemStack.EMPTY;
                 }
 
-                ItemStack remainder = InventoryUtil.storeItems( storeStack, turtle.getItemHandler(), turtle.getSelectedSlot() );
+                ItemStack remainder = InventoryUtil.storeItems( storeStack, turtle.getItemHandler(), turtle.getSelectedSlot(), false );
 
                 if( remainder != storeStack )
                 {

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleSuckCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleSuckCommand.java
@@ -5,6 +5,7 @@
  */
 package dan200.computercraft.shared.turtle.core;
 
+import dan200.computercraft.ComputerCraft;
 import dan200.computercraft.api.turtle.ITurtleAccess;
 import dan200.computercraft.api.turtle.ITurtleCommand;
 import dan200.computercraft.api.turtle.TurtleAnimation;
@@ -60,28 +61,30 @@ public class TurtleSuckCommand implements ITurtleCommand
         {
             ItemStorage inventory = ItemStorage.wrap( inventoryContainer );
 
-            // Take from inventory of thing in front
-            ItemStack stack = InventoryUtil.takeItems( quantity, inventory, false );
-            if( stack.isEmpty() ) return TurtleCommandResult.failure( "No items to take" );
+            // Simulate extracting from inventory of thing in front
+            ItemStack simulatedExtraction = InventoryUtil.takeItems( quantity, inventory, true );
+            if( simulatedExtraction.isEmpty() ) return TurtleCommandResult.failure( "No items to take" );
 
-            // Try to place into the turtle
+            // Simulate inserting result into turtle's inventory
+            ItemStack simulatedRemainder = InventoryUtil.storeItems( simulatedExtraction, turtle.getItemHandler(), turtle.getSelectedSlot(), true );
+            if( simulatedRemainder == simulatedExtraction ) return TurtleCommandResult.failure( "No space for items" );
+
+            // Calculate how many items successfully transferred
+            int transferCount = simulatedExtraction.getCount() - simulatedRemainder.getCount();
+
+            // Execute the transaction
+            ItemStack stack = InventoryUtil.takeItems( transferCount, inventory, false );
             ItemStack remainder = InventoryUtil.storeItems( stack, turtle.getItemHandler(), turtle.getSelectedSlot(), false );
+
             if( !remainder.isEmpty() )
             {
-                // Put the remainder back in the inventory
-                InventoryUtil.storeItems( remainder, inventory, false );
+                ComputerCraft.log.error( "Items were lost during a TurtleSuckCommand!" );
+                ComputerCraft.log.error( String.format( "from=%s quantity=%d, direction=%s", inventory, quantity, direction ) );
+                ComputerCraft.log.error( "Please report this at https://github.com/cc-tweaked/cc-restitched/issues" );
             }
 
-            // Return true if we consumed anything
-            if( remainder != stack )
-            {
-                turtle.playAnimation( TurtleAnimation.WAIT );
-                return TurtleCommandResult.success();
-            }
-            else
-            {
-                return TurtleCommandResult.failure( "No space for items" );
-            }
+            turtle.playAnimation( TurtleAnimation.WAIT );
+            return TurtleCommandResult.success();
         }
         else
         {

--- a/src/main/java/dan200/computercraft/shared/turtle/core/TurtleTransferToCommand.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/core/TurtleTransferToCommand.java
@@ -30,7 +30,7 @@ public class TurtleTransferToCommand implements ITurtleCommand
     public TurtleCommandResult execute( @Nonnull ITurtleAccess turtle )
     {
         // Take stack
-        ItemStack stack = InventoryUtil.takeItems( quantity, turtle.getItemHandler(), turtle.getSelectedSlot(), 1, turtle.getSelectedSlot() );
+        ItemStack stack = InventoryUtil.takeItems( quantity, turtle.getItemHandler(), turtle.getSelectedSlot(), 1, turtle.getSelectedSlot(), false );
         if( stack.isEmpty() )
         {
             turtle.playAnimation( TurtleAnimation.WAIT );
@@ -38,11 +38,11 @@ public class TurtleTransferToCommand implements ITurtleCommand
         }
 
         // Store stack
-        ItemStack remainder = InventoryUtil.storeItems( stack, turtle.getItemHandler(), slot, 1, slot );
+        ItemStack remainder = InventoryUtil.storeItems( stack, turtle.getItemHandler(), slot, 1, slot, false );
         if( !remainder.isEmpty() )
         {
             // Put the remainder back
-            InventoryUtil.storeItems( remainder, turtle.getItemHandler(), turtle.getSelectedSlot(), 1, turtle.getSelectedSlot() );
+            InventoryUtil.storeItems( remainder, turtle.getItemHandler(), turtle.getSelectedSlot(), 1, turtle.getSelectedSlot(), false );
         }
 
         // Return true if we moved anything

--- a/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleTool.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/upgrades/TurtleTool.java
@@ -270,7 +270,7 @@ public class TurtleTool extends AbstractTurtleUpgrade
 
     private static Function<ItemStack, ItemStack> turtleDropConsumer( BlockEntity tile, ITurtleAccess turtle )
     {
-        return drop -> tile.isRemoved() ? drop : InventoryUtil.storeItems( drop, turtle.getItemHandler(), turtle.getSelectedSlot() );
+        return drop -> tile.isRemoved() ? drop : InventoryUtil.storeItems( drop, turtle.getItemHandler(), turtle.getSelectedSlot(), false );
     }
 
     private static void stopConsuming( BlockEntity tile, ITurtleAccess turtle )

--- a/src/main/java/dan200/computercraft/shared/util/InventoryUtil.java
+++ b/src/main/java/dan200/computercraft/shared/util/InventoryUtil.java
@@ -103,19 +103,19 @@ public final class InventoryUtil
     // Methods for placing into inventories:
 
     @Nonnull
-    public static ItemStack storeItems( @Nonnull ItemStack itemstack, ItemStorage inventory, int begin )
+    public static ItemStack storeItems( @Nonnull ItemStack itemstack, ItemStorage inventory, int begin, boolean simulate )
     {
-        return storeItems( itemstack, inventory, 0, inventory.size(), begin );
+        return storeItems( itemstack, inventory, 0, inventory.size(), begin, simulate );
     }
 
     @Nonnull
-    public static ItemStack storeItems( @Nonnull ItemStack itemstack, ItemStorage inventory )
+    public static ItemStack storeItems( @Nonnull ItemStack itemstack, ItemStorage inventory, boolean simulate )
     {
-        return storeItems( itemstack, inventory, 0, inventory.size(), 0 );
+        return storeItems( itemstack, inventory, 0, inventory.size(), 0, simulate );
     }
 
     @Nonnull
-    public static ItemStack storeItems( @Nonnull ItemStack stack, ItemStorage inventory, int start, int range, int begin )
+    public static ItemStack storeItems( @Nonnull ItemStack stack, ItemStorage inventory, int start, int range, int begin, boolean simulate )
     {
         if( stack.isEmpty() ) return ItemStack.EMPTY;
 
@@ -125,7 +125,7 @@ public final class InventoryUtil
         {
             int slot = start + (i + begin - start) % range;
             if( remainder.isEmpty() ) break;
-            remainder = inventory.store( slot, remainder, false );
+            remainder = inventory.store( slot, remainder, simulate );
         }
         return areItemsEqual( stack, remainder ) ? stack : remainder;
     }
@@ -133,19 +133,19 @@ public final class InventoryUtil
     // Methods for taking out of inventories
 
     @Nonnull
-    public static ItemStack takeItems( int count, ItemStorage inventory, int begin )
+    public static ItemStack takeItems( int count, ItemStorage inventory, int begin, boolean simulate )
     {
-        return takeItems( count, inventory, 0, inventory.size(), begin );
+        return takeItems( count, inventory, 0, inventory.size(), begin, simulate );
     }
 
     @Nonnull
-    public static ItemStack takeItems( int count, ItemStorage inventory )
+    public static ItemStack takeItems( int count, ItemStorage inventory, boolean simulate )
     {
-        return takeItems( count, inventory, 0, inventory.size(), 0 );
+        return takeItems( count, inventory, 0, inventory.size(), 0, simulate );
     }
 
     @Nonnull
-    public static ItemStack takeItems( int count, ItemStorage inventory, int start, int range, int begin )
+    public static ItemStack takeItems( int count, ItemStorage inventory, int start, int range, int begin, boolean simulate )
     {
         // Combine multiple stacks from inventory into one if necessary
         ItemStack partialStack = ItemStack.EMPTY;
@@ -157,7 +157,7 @@ public final class InventoryUtil
             if( count <= 0 ) break;
 
             // If this doesn't slot, abort.
-            ItemStack extracted = inventory.take( slot, count, partialStack, false );
+            ItemStack extracted = inventory.take( slot, count, partialStack, simulate );
             if( extracted.isEmpty() )
             {
                 continue;

--- a/src/main/java/dan200/computercraft/shared/util/ItemStorage.java
+++ b/src/main/java/dan200/computercraft/shared/util/ItemStorage.java
@@ -197,6 +197,12 @@ public interface ItemStorage
                 return stack;
             }
         }
+
+        @Override
+        public String toString()
+        {
+            return String.format( "%s{type=%s}", getClass().getSimpleName(), inventory.getClass().getSimpleName() );
+        }
     }
 
     class SidedInventoryWrapper extends InventoryWrapper
@@ -247,6 +253,12 @@ public interface ItemStorage
                 return stack;
             }
             return super.store( mappedSlot, stack, simulate );
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format( "%s{type=%s, facing=%s}", getClass().getSimpleName(), inventory.getClass().getSimpleName(), facing );
         }
     }
 
@@ -316,6 +328,12 @@ public interface ItemStorage
         public ItemStorage view( int start, int size )
         {
             return new View( parent, this.start + start, size );
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format( "%s{parent=%s, start=%d, size=%d}", getClass().getSimpleName(), parent, start, size );
         }
     }
 }


### PR DESCRIPTION
The problem was that we were extracting up to the limit before we knew how many items the destination inventory could actually accept, and then we would fail to replace the remaining items back into the furnace output slot since it's protected from insertions. My fix is to simulate the transaction first, see how many items were successfully transferred, and only then mutate the inventories by that amount.

I would appreciate any reviews or testing on this because I feel like there are probably edge cases I haven't considered and I don't have a good world to test this on. I added some error logging in case it detects that items were lost.

There was also a similar issue with the turtle suck command that I applied the same sort of fix to, along with the error logging.