### PR TITLE
Fix for #147

### DIFF
--- a/config/license/api.txt
+++ b/config/license/api.txt
@@ -1,3 +1,3 @@
 This file is part of the public ComputerCraft API - http://www.computercraft.info
-Copyright Daniel Ratcliffe, 2011-${year}. This API may be redistributed unmodified and in full only.
+Copyright Daniel Ratcliffe, 2011-2022. This API may be redistributed unmodified and in full only.
 For help using the API, and posting your mods, visit the forums at computercraft.info.

--- a/config/license/main.txt
+++ b/config/license/main.txt
@@ -1,3 +1,3 @@
 This file is part of ComputerCraft - http://www.computercraft.info
-Copyright Daniel Ratcliffe, 2011-${year}. Do not distribute without permission.
+Copyright Daniel Ratcliffe, 2011-2022. Do not distribute without permission.
 Send enquiries to dratcliffe@gmail.com

--- a/src/main/java/dan200/computercraft/shared/computer/core/ServerComputer.java
+++ b/src/main/java/dan200/computercraft/shared/computer/core/ServerComputer.java
@@ -191,6 +191,10 @@ public class ServerComputer extends ServerTerminal implements IComputer, IComput
 
     public void broadcastDelete()
     {
+        // We could be in the process of shutting down the server, so we can't send packets in this case.
+        MinecraftServer server = GameInstanceUtils.getServer();
+        if( server == null || server.isStopped() ) return;
+
         // Send deletion to client
         NetworkHandler.sendToAllPlayers( new ComputerDeletedClientMessage( getInstanceID() ) );
     }


### PR DESCRIPTION
As mentioned in #147, there's a huge issue in singleplayer on 1.18.2 v1.100.8 where chunks with computers in them won't save, unless the player stays on the menu screen for long enough. I assume there's some good reason that the way it's fixed in c09735c can't or shouldn't be backported, but the issue pretty much makes this version of the mod unplayable. 

Checking if the server still exists before broadcasting a computer delete message fixes it (the same way it's done in UpgradeSpeakerPeripheral)